### PR TITLE
Adds a statement generator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ pgpSecretRing := file(s"$gpgFolder/secring.gpg")
 lazy val commonDependencies: Seq[ModuleID] = Seq(
   %%("cats-core"),
   %%("freestyle-async"),
+  %%("shapeless"),
   %("cassandra-driver-core"),
   %("cassandra-driver-mapping"),
   %("cassandra-driver-extras"))

--- a/core/src/main/scala/freestyle/cassandra/query/FieldLister.scala
+++ b/core/src/main/scala/freestyle/cassandra/query/FieldLister.scala
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Based on blog post by Mike Limansky: "Generating SQL queries with shapeless"
+ * http://limansky.me/posts/2017-02-02-generating-sql-queries-with-shapeless.html
  */
 
 package freestyle.cassandra.query

--- a/core/src/main/scala/freestyle/cassandra/query/FieldLister.scala
+++ b/core/src/main/scala/freestyle/cassandra/query/FieldLister.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra.query
+
+import shapeless._
+import shapeless.labelled.FieldType
+
+trait FieldLister[A] {
+  val list: List[String]
+}
+
+trait FieldListerPrimitive {
+  implicit def primitiveFieldLister[K <: Symbol, H, T <: HList](
+      implicit witness: Witness.Aux[K],
+      tLister: FieldLister[T]): FieldLister[FieldType[K, H] :: T] =
+    new FieldLister[FieldType[K, H] :: T] {
+      override val list: List[String] = witness.value.name :: tLister.list
+    }
+}
+
+trait FieldListerGeneric extends FieldListerPrimitive {
+
+  implicit def genericLister[A, R](
+      implicit gen: LabelledGeneric.Aux[A, R],
+      lister: Lazy[FieldLister[R]]): FieldLister[A] = new FieldLister[A] {
+    override val list: List[String] = lister.value.list
+  }
+
+  implicit val hnilLister: FieldLister[HNil] = new FieldLister[HNil] {
+    override val list = Nil
+  }
+
+}
+
+object FieldLister extends FieldListerGeneric
+
+object FieldListerExpanded extends FieldListerGeneric {
+
+  implicit def hconsLister[K, H, T <: HList](
+      implicit hLister: Lazy[FieldLister[H]],
+      tLister: FieldLister[T]): FieldLister[FieldType[K, H] :: T] =
+    new FieldLister[FieldType[K, H] :: T] {
+      override val list: List[String] = hLister.value.list ++ tLister.list
+    }
+
+}

--- a/core/src/main/scala/freestyle/cassandra/query/StatementGenerator.scala
+++ b/core/src/main/scala/freestyle/cassandra/query/StatementGenerator.scala
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Based on blog post by Mike Limansky: "Generating SQL queries with shapeless"
+ * http://limansky.me/posts/2017-02-02-generating-sql-queries-with-shapeless.html
  */
 
 package freestyle.cassandra.query

--- a/core/src/main/scala/freestyle/cassandra/query/StatementGenerator.scala
+++ b/core/src/main/scala/freestyle/cassandra/query/StatementGenerator.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra.query
+
+trait StatementGenerator[A] {
+  def select(table: String): String
+  def insert(table: String): String
+}
+
+object StatementGenerator {
+  def apply[A](implicit sg: StatementGenerator[A]): StatementGenerator[A] =
+    sg
+
+  implicit def genericGenerator[A](implicit fieldLister: FieldLister[A]): StatementGenerator[A] =
+    new StatementGenerator[A] {
+      override def select(table: String): String = {
+        val fields = fieldLister.list.mkString(",")
+        s"SELECT $fields FROM $table"
+      }
+
+      override def insert(table: String): String = {
+        val fieldNames   = fieldLister.list
+        val fields       = fieldNames.mkString(",")
+        val placeholders = List.fill(fieldNames.size)("?").mkString(",")
+        s"INSERT INTO $table ($fields) VALUES ($placeholders)"
+      }
+    }
+}

--- a/core/src/test/scala/freestyle/cassandra/ListenableFuture2AsyncMSpec.scala
+++ b/core/src/test/scala/freestyle/cassandra/ListenableFuture2AsyncMSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
+
+import scala.concurrent.{duration, Await, Future}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ListenableFuture2AsyncMSpec
+    extends WordSpec
+    with Matchers
+    with OneInstancePerTest
+    with MockFactory
+    with TestUtils {
+
+  import freestyle.async.implicits._
+  import freestyle.cassandra.implicits._
+
+  val handler: ListenableFuture2AsyncM[Future] = listenableFuture2Async[Future]
+
+  "ListenableFuture2AsyncM" should {
+
+    "return a successfully future when a successfully listenable future is passed" in {
+      val value = "Hello World!"
+      Await.result(handler(successfulFuture(value)), duration.Duration.Inf) shouldEqual value
+    }
+
+    "return a failed future when a failed listenable future is passed" in {
+      val value = "Hello World!"
+      val future = handler(failedFuture[String]) recover {
+        case _ => value
+      }
+      Await.result(future, duration.Duration.Inf) shouldEqual value
+    }
+
+  }
+
+}

--- a/core/src/test/scala/freestyle/cassandra/ListenableFutureHandlerSpec.scala
+++ b/core/src/test/scala/freestyle/cassandra/ListenableFutureHandlerSpec.scala
@@ -17,7 +17,6 @@
 package freestyle.cassandra
 
 import com.datastax.driver.core._
-import freestyle.cassandra.implicits.ListenableFutureHandler
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
 
@@ -36,7 +35,8 @@ class ListenableFutureHandlerSpec
   val queryString: String            = "SELECT * FROM table;"
   val mapValues: Map[String, AnyRef] = Map("param1" -> "value1", "param2" -> "value2")
 
-  val handler = new ListenableFutureHandler()(sessionMock)
+  import freestyle.cassandra.implicits._
+  val handler: ListenableFutureHandler = listenableFutureHandler(sessionMock)
 
   "ListenableFutureHandler" should {
 

--- a/core/src/test/scala/freestyle/cassandra/query/StatementGeneratorSpec.scala
+++ b/core/src/test/scala/freestyle/cassandra/query/StatementGeneratorSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra.query
+
+import org.scalatest.{Matchers, WordSpec}
+import StatementGenerator._
+
+class StatementGeneratorSpec extends WordSpec with Matchers {
+
+  case class A(a1: Int, a2: String, a3: Boolean)
+
+  case class B(b1: Long, b2: String)
+
+  case class C(c1: String, c2: B)
+
+  "insert" should {
+
+    "generate a right statement for a regular case class" in {
+
+      import FieldLister._
+      StatementGenerator[A].insert("A") shouldBe "INSERT INTO A (a1,a2,a3) VALUES (?,?,?)"
+
+    }
+
+    "generate a right statement for a case class with another embedded case class" in {
+
+      import FieldLister._
+      StatementGenerator[C].insert("C") shouldBe "INSERT INTO C (c1,c2) VALUES (?,?)"
+
+    }
+
+    "generate a right expanded statement for a case class with another embedded case class" in {
+
+      import StatementGenerator._
+      import FieldListerExpanded._
+      StatementGenerator[C].insert("C") shouldBe "INSERT INTO C (c1,b1,b2) VALUES (?,?,?)"
+
+    }
+
+  }
+
+  "select" should {
+
+    "generate a right statement for a regular case class" in {
+
+      import FieldLister._
+      StatementGenerator[A].select("A") shouldBe "SELECT a1,a2,a3 FROM A"
+
+    }
+
+    "generate a right statement for a case class with another embedded case class" in {
+
+      import FieldLister._
+      StatementGenerator[C].select("C") shouldBe "SELECT c1,c2 FROM C"
+
+    }
+
+    "generate a right expanded statement for a case class with another embedded case class" in {
+
+      import FieldListerExpanded._
+      StatementGenerator[C].select("C") shouldBe "SELECT c1,b1,b2 FROM C"
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
Fixes #10 

This code is based on the great post [Generating SQL queries with shapeless](http://limansky.me/posts/2017-02-02-generating-sql-queries-with-shapeless.html) by [Mike Limansky](https://github.com/limansky)

It adds a statement generator for generating insert and select queries from a specific Type. It uses a FieldLister for that. The `FieldListerExpanded` recursively handles all of the fields and make a flat list of the primitive ones.

Please, @raulraja, could you review? Thanks!