### PR TITLE
Adds the cluster configuration for Typesafe Config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,15 +9,16 @@ lazy val commonDependencies: Seq[ModuleID] = Seq(
   %%("circe-core"),
   %%("circe-parser"),
   %%("circe-generic"),
+  %%("classy-core"),
+  %%("classy-config-typesafe"),
   %("cassandra-driver-core"),
   %("cassandra-driver-mapping"),
   %("cassandra-driver-extras"),
-  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6")
+  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6"
+)
 
-lazy val testDependencies: Seq[ModuleID] = Seq(
-  %%("scalatest") % "test",
-  %%("scalamockScalatest") % "test",
-  %%("scalacheck") % "test")
+lazy val testDependencies: Seq[ModuleID] =
+  Seq(%%("scalatest") % "test", %%("scalamockScalatest") % "test", %%("scalacheck") % "test")
 
 lazy val root = project
   .in(file("."))
@@ -26,7 +27,8 @@ lazy val root = project
   .dependsOn(core)
   .aggregate(core)
 
-lazy val core = project.in(file("core"))
+lazy val core = project
+  .in(file("core"))
   .settings(moduleName := "freestyle-cassandra-core")
   .settings(libraryDependencies ++= commonDependencies)
   .settings(libraryDependencies ++= testDependencies)

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val commonDependencies: Seq[ModuleID] = Seq(
 )
 
 lazy val testDependencies: Seq[ModuleID] =
-  Seq(%%("scalatest") % "test", %%("scalamockScalatest") % "test", %%("scalacheck") % "test")
+  Seq(%%("scalatest"), %%("scalamockScalatest"), %%("scalacheck")) map (_  % "test")
 
 lazy val root = project
   .in(file("."))

--- a/core/src/main/scala/config/decoders.scala
+++ b/core/src/main/scala/config/decoders.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra
+package config
+
+import java.util.concurrent.Executor
+
+import classy.{Decoder, Read}
+import classy.config._
+import com.datastax.driver.core.ProtocolOptions.Compression
+import com.datastax.driver.core._
+import com.datastax.driver.core.policies._
+import com.typesafe.config.Config
+
+import collection.JavaConverters._
+
+object decoders {
+
+  def builderCustomProp[Builder, T](b: Builder, attr: String)(f: (Builder, T) => Builder)(
+      implicit r: Read[Config, T]): ConfigDecoder[Builder] =
+    builderProp[Builder, T](b, attr, b => f(b, _))
+
+  def builderProp[Builder, T](b: Builder, attr: String, f: Builder => (T => Builder))(
+      implicit r: Read[Config, T]): ConfigDecoder[Builder] =
+    readConfig[Option[T]](attr).map {
+      case Some(v) => f(b)(v)
+      case _       => b
+    }
+
+  import config.implicits._
+  import config.implicits.datastax._
+
+  abstract class DecoderBuilder[Builder] {
+
+    def empty: Builder
+
+    def fields: List[(Builder) => ConfigDecoder[Builder]]
+
+    def customField[T](b: Builder, attr: String)(f: (Builder, T) => Builder)(
+        implicit r: Read[Config, T]): ConfigDecoder[Builder] =
+      builderCustomProp[Builder, T](b, attr)(f)
+
+    def field[T](b: Builder, attr: String, f: Builder => (T => Builder))(
+        implicit r: Read[Config, T]): ConfigDecoder[Builder] = builderProp[Builder, T](b, attr, f)
+
+    def flagField(b: Builder, attr: String, f: Builder => Builder): ConfigDecoder[Builder] =
+      customField[Boolean](b, attr) {
+        case (builder, true) => f(builder)
+        case (builder, _)    => builder
+      }
+
+    def build: ConfigDecoder[Builder] =
+      fields.foldLeft[ConfigDecoder[Builder]](Decoder.const(empty)) { (d, b) =>
+        d.flatMap(b)
+      }
+
+  }
+
+  class PoolingOptionsBuilder extends DecoderBuilder[PoolingOptions] {
+
+    override def empty: PoolingOptions = new PoolingOptions
+
+    override def fields: List[(PoolingOptions) => ConfigDecoder[PoolingOptions]] = List(
+      customField[ConnectionsPerHost](_, "connectionsPerHost") { (b, v) =>
+        b.setConnectionsPerHost(v.distance, v.core, v.max)
+      },
+      customField[CoreConnectionsPerHost](_, "coreConnectionsPerHost") { (b, v) =>
+        b.setCoreConnectionsPerHost(v.distance, v.newCoreConnections)
+      },
+      customField[MaxConnectionsPerHost](_, "maxConnectionsPerHost") { (b, v) =>
+        b.setMaxConnectionsPerHost(v.distance, v.newMaxConnections)
+      },
+      customField[NewConnectionThreshold](_, "newConnectionThreshold") { (b, v) =>
+        b.setNewConnectionThreshold(v.distance, v.newValue)
+      },
+      field[Int](_, "heartbeatIntervalSeconds", _.setHeartbeatIntervalSeconds),
+      field[Int](_, "idleTimeoutSeconds", _.setIdleTimeoutSeconds),
+      field[Int](_, "maxQueueSize", _.setMaxQueueSize),
+      field[Int](_, "poolTimeoutMillis", _.setPoolTimeoutMillis),
+      field[Executor](_, "initializationExecutor", _.setInitializationExecutor)
+    )
+  }
+
+  class QueryOptionsBuilder extends DecoderBuilder[QueryOptions] {
+
+    override def empty: QueryOptions = new QueryOptions
+
+    override def fields: List[(QueryOptions) => ConfigDecoder[QueryOptions]] = List(
+      field[ConsistencyLevel](_, "consistencyLevel", _.setConsistencyLevel),
+      field[ConsistencyLevel](_, "serialConsistencyLevel", _.setSerialConsistencyLevel),
+      field[Boolean](_, "defaultIdempotence", _.setDefaultIdempotence),
+      field[Int](_, "fetchSize", _.setFetchSize),
+      field[Int](_, "maxPendingRefreshNodeListRequests", _.setMaxPendingRefreshNodeListRequests),
+      field[Int](_, "maxPendingRefreshNodeRequests", _.setMaxPendingRefreshNodeRequests),
+      field[Int](_, "maxPendingRefreshSchemaRequests", _.setMaxPendingRefreshSchemaRequests),
+      field[Boolean](_, "metadataEnabled", _.setMetadataEnabled),
+      field[Boolean](_, "prepareOnAllHosts", _.setPrepareOnAllHosts),
+      field[Int](_, "refreshNodeIntervalMillis", _.setRefreshNodeIntervalMillis),
+      field[Int](_, "refreshNodeListIntervalMillis", _.setRefreshNodeListIntervalMillis),
+      field[Int](_, "refreshSchemaIntervalMillis", _.setRefreshSchemaIntervalMillis),
+      field[Boolean](_, "reprepareOnUp", _.setReprepareOnUp)
+    )
+  }
+
+  class SocketOptionsBuilder extends DecoderBuilder[SocketOptions] {
+    override def empty: SocketOptions = new SocketOptions
+
+    override def fields: List[(SocketOptions) => ConfigDecoder[SocketOptions]] = List(
+      field[Int](_, "connectTimeoutMillis", _.setConnectTimeoutMillis),
+      field[Boolean](_, "keepAlive", _.setKeepAlive),
+      field[Int](_, "readTimeoutMillis", _.setReadTimeoutMillis),
+      field[Int](_, "receiveBufferSize", _.setReceiveBufferSize),
+      field[Int](_, "sendBufferSize", _.setSendBufferSize),
+      field[Boolean](_, "reuseAddress", _.setReuseAddress),
+      field[Int](_, "soLinger", _.setSoLinger),
+      field[Boolean](_, "tcpNoDelay", _.setTcpNoDelay)
+    )
+  }
+
+  class ClusterDecoderBuilder extends DecoderBuilder[Cluster.Builder] {
+    override def empty: Cluster.Builder = new Cluster.Builder
+
+    override def fields: List[(Cluster.Builder) => ConfigDecoder[Cluster.Builder]] = List(
+      customField[ContactPoints](_, "contactPoints") {
+        case (b, ContactPointList(l))         => b.addContactPoints(l.asJava)
+        case (b, ContactPointWithPortList(l)) => b.addContactPointsWithPorts(l.asJava)
+      },
+      customField[Credentials](_, "credentials") { (b, v) =>
+        b.withCredentials(v.username, v.password)
+      },
+      flagField(_, "allowBetaProtocolVersion", _.allowBetaProtocolVersion),
+      flagField(_, "enableSSL", _.withSSL),
+      field[String](_, "name", _.withClusterName),
+      field[AddressTranslator](_, "addressTranslator", _.withAddressTranslator),
+      field[AuthProvider](_, "authProvider", _.withAuthProvider),
+      field[LoadBalancingPolicy](_, "loadBalancingPolicy", _.withLoadBalancingPolicy),
+      field[ReconnectionPolicy](_, "reconnectionPolicy", _.withReconnectionPolicy),
+      field[RetryPolicy](_, "retryPolicy", _.withRetryPolicy),
+      field[SpeculativeExecutionPolicy](
+        _,
+        "speculativeExecutionPolicy",
+        _.withSpeculativeExecutionPolicy),
+      field[SSLOptions](_, "sslOptions", _.withSSL),
+      field[ThreadingOptions](_, "threadingOptions", _.withThreadingOptions),
+      field[TimestampGenerator](_, "timestampGenerator", _.withTimestampGenerator),
+      field[Int](_, "maxSchemaAgreementWaitSeconds", _.withMaxSchemaAgreementWaitSeconds),
+      field[Int](_, "port", _.withPort),
+      field[Compression](_, "compression", _.withCompression),
+      field[ProtocolVersion](_, "protocolVersion", _.withProtocolVersion),
+      field[PoolingOptions](_, "poolingOptions", _.withPoolingOptions),
+      field[QueryOptions](_, "queryOptions", _.withQueryOptions),
+      field[SocketOptions](_, "socketOptions", _.withSocketOptions)
+    )
+  }
+
+  implicit val poolingOptionsDecoder: ConfigDecoder[PoolingOptions] =
+    new PoolingOptionsBuilder().build
+
+  implicit val queryOptionsDecoder: ConfigDecoder[QueryOptions] =
+    new QueryOptionsBuilder().build
+
+  implicit val socketOptionsDecoder: ConfigDecoder[SocketOptions] =
+    new SocketOptionsBuilder().build
+
+  implicit val clusterBuilderDecoder: ConfigDecoder[Cluster.Builder] =
+    new ClusterDecoderBuilder().build
+
+}

--- a/core/src/main/scala/config/implicits/datastax.scala
+++ b/core/src/main/scala/config/implicits/datastax.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra
+package config.implicits
+
+import java.net.{InetAddress, InetSocketAddress}
+import java.util.concurrent.Executor
+
+import cats.implicits._
+import classy.DecodeError.WrongType
+import classy.config._
+import classy.{DecodeError, Decoder, Read}
+import com.datastax.driver.core.ProtocolOptions.Compression
+import com.datastax.driver.core.policies._
+import com.datastax.driver.core._
+import com.typesafe.config.Config
+import config._
+
+object datastax {
+
+  import config.implicits._
+
+  implicit val contactPointListRead: Read[Config, ContactPoints] = {
+    def trav[T](
+        l: List[String],
+        f: (String) => Either[DecodeError, T],
+        apply: List[T] => ContactPoints): Either[DecodeError, ContactPoints] =
+      l.traverse(f).map(apply)
+
+    def inetAddressParser(s: String): Either[DecodeError, InetAddress] = {
+      import cats.syntax.either._
+      Either.catchNonFatal(InetAddress.getByName(s)).leftMap(_ => WrongType("X.X.X.X", Some(s)))
+    }
+
+    def inetSocketAddressParser(s: String): Either[DecodeError, InetSocketAddress] = {
+      val SockedAddress = "([^:]+):([0-9]+)".r
+      s match {
+        case SockedAddress(host, port) => Right(new InetSocketAddress(host, port.toInt))
+        case _                         => Left(WrongType("<hostName>:<port>", Some(s)))
+      }
+    }
+
+    read[List[String], ContactPoints] { list =>
+      trav[InetSocketAddress](list, inetSocketAddressParser, ContactPointWithPortList)
+        .recoverWith {
+          case _ =>
+            trav[InetAddress](list, inetAddressParser, ContactPointList)
+        } match {
+        case Right(t) => Decoder.const(t)
+        case Left(e)  => Decoder.fail(e)
+      }
+    }
+  }
+
+  implicit val executorRead                   = instanceRead[Executor]
+  implicit val addressTranslatorRead          = instanceRead[AddressTranslator]
+  implicit val authProviderRead               = instanceRead[AuthProvider]
+  implicit val loadBalancingRead              = instanceRead[LoadBalancingPolicy]
+  implicit val reconnectionPolicyRead         = instanceRead[ReconnectionPolicy]
+  implicit val retryPolicyRead                = instanceRead[RetryPolicy]
+  implicit val speculativeExecutionPolicyRead = instanceRead[SpeculativeExecutionPolicy]
+  implicit val sslOptionsRead                 = instanceRead[SSLOptions]
+  implicit val threadingOptionsRead           = instanceRead[ThreadingOptions]
+  implicit val timestampGeneratorRead         = instanceRead[TimestampGenerator]
+
+  implicit val hostDistances: List[(String, HostDistance)] =
+    ("ignored", HostDistance.IGNORED) ::
+      ("local", HostDistance.LOCAL) ::
+      ("remote", HostDistance.REMOTE) :: Nil
+
+  implicit val consistencyLevels: List[(String, ConsistencyLevel)] =
+    ("ALL", ConsistencyLevel.ALL) ::
+      ("ANY", ConsistencyLevel.ANY) ::
+      ("EACH_QUORUM", ConsistencyLevel.EACH_QUORUM) ::
+      ("LOCAL_ONE", ConsistencyLevel.LOCAL_ONE) ::
+      ("LOCAL_QUORUM", ConsistencyLevel.LOCAL_QUORUM) ::
+      ("LOCAL_SERIAL", ConsistencyLevel.LOCAL_SERIAL) ::
+      ("ONE", ConsistencyLevel.ONE) ::
+      ("QUORUM", ConsistencyLevel.QUORUM) ::
+      ("SERIAL", ConsistencyLevel.SERIAL) ::
+      ("THREE", ConsistencyLevel.THREE) ::
+      ("TWO", ConsistencyLevel.TWO) :: Nil
+
+  implicit val protocolVersions: List[(String, ProtocolVersion)] =
+    ("V1", ProtocolVersion.V1) ::
+      ("V2", ProtocolVersion.V2) ::
+      ("V3", ProtocolVersion.V3) ::
+      ("V4", ProtocolVersion.V4) ::
+      ("V5", ProtocolVersion.V5) :: Nil
+
+  implicit val compressions: List[(String, Compression)] =
+    ("lz4", Compression.LZ4) :: ("snappy", Compression.SNAPPY) :: ("none", Compression.NONE) :: Nil
+
+  implicit val credentialsRead: Read[Config, Credentials] = Read.instance[Config, Credentials] {
+    path =>
+      readConfig[String](s"$path.username")
+        .join(readConfig[String](s"$path.password"))
+        .map(Credentials.tupled)
+  }
+
+  implicit val connectionsPerHostDecoder: Read[Config, ConnectionsPerHost] =
+    Read.instance[Config, ConnectionsPerHost] { path =>
+      readConfig[HostDistance](s"$path.instance")
+        .join(readConfig[Int](s"$path.core"))
+        .join(readConfig[Int](s"$path.max"))
+        .map(ConnectionsPerHost.tupled)
+    }
+
+  implicit val coreConnectionsPerHostDecoder: Read[Config, CoreConnectionsPerHost] =
+    Read.instance[Config, CoreConnectionsPerHost] { path =>
+      readConfig[HostDistance](s"$path.distance")
+        .join(readConfig[Int](s"$path.newCoreConnections"))
+        .map(CoreConnectionsPerHost.tupled)
+    }
+
+  implicit val maxConnectionsPerHostDecoder: Read[Config, MaxConnectionsPerHost] =
+    Read.instance[Config, MaxConnectionsPerHost] { path =>
+      readConfig[HostDistance](s"$path.distance")
+        .join(readConfig[Int](s"$path.maxCoreConnections"))
+        .map(MaxConnectionsPerHost.tupled)
+    }
+
+  implicit val maxRequestsPerHostDecoder: Read[Config, MaxRequestsPerConnection] =
+    Read.instance[Config, MaxRequestsPerConnection] { path =>
+      readConfig[HostDistance](s"$path.distance")
+        .join(readConfig[Int](s"$path.newMaxRequests"))
+        .map(MaxRequestsPerConnection.tupled)
+    }
+
+  implicit val newConnectionThresholdDecoder: Read[Config, NewConnectionThreshold] =
+    Read.instance[Config, NewConnectionThreshold] { path =>
+      readConfig[HostDistance](s"$path.distance")
+        .join(readConfig[Int](s"$path.newValue"))
+        .map(NewConnectionThreshold.tupled)
+    }
+
+}

--- a/core/src/main/scala/config/implicits/datastax.scala
+++ b/core/src/main/scala/config/implicits/datastax.scala
@@ -41,10 +41,8 @@ object datastax {
         apply: List[T] => ContactPoints): Either[DecodeError, ContactPoints] =
       l.traverse(f).map(apply)
 
-    def inetAddressParser(s: String): Either[DecodeError, InetAddress] = {
-      import cats.syntax.either._
+    def inetAddressParser(s: String): Either[DecodeError, InetAddress] =
       Either.catchNonFatal(InetAddress.getByName(s)).leftMap(_ => WrongType("X.X.X.X", Some(s)))
-    }
 
     def inetSocketAddressParser(s: String): Either[DecodeError, InetSocketAddress] = {
       val SockedAddress = "([^:]+):([0-9]+)".r
@@ -77,33 +75,37 @@ object datastax {
   implicit val threadingOptionsRead           = instanceRead[ThreadingOptions]
   implicit val timestampGeneratorRead         = instanceRead[TimestampGenerator]
 
-  implicit val hostDistances: List[(String, HostDistance)] =
-    ("ignored", HostDistance.IGNORED) ::
-      ("local", HostDistance.LOCAL) ::
-      ("remote", HostDistance.REMOTE) :: Nil
+  implicit val hostDistances: Map[String, HostDistance] =
+    Map(
+      "ignored" -> HostDistance.IGNORED,
+      "local"   -> HostDistance.LOCAL,
+      "remote"  -> HostDistance.REMOTE)
 
-  implicit val consistencyLevels: List[(String, ConsistencyLevel)] =
-    ("ALL", ConsistencyLevel.ALL) ::
-      ("ANY", ConsistencyLevel.ANY) ::
-      ("EACH_QUORUM", ConsistencyLevel.EACH_QUORUM) ::
-      ("LOCAL_ONE", ConsistencyLevel.LOCAL_ONE) ::
-      ("LOCAL_QUORUM", ConsistencyLevel.LOCAL_QUORUM) ::
-      ("LOCAL_SERIAL", ConsistencyLevel.LOCAL_SERIAL) ::
-      ("ONE", ConsistencyLevel.ONE) ::
-      ("QUORUM", ConsistencyLevel.QUORUM) ::
-      ("SERIAL", ConsistencyLevel.SERIAL) ::
-      ("THREE", ConsistencyLevel.THREE) ::
-      ("TWO", ConsistencyLevel.TWO) :: Nil
+  implicit val consistencyLevels: Map[String, ConsistencyLevel] =
+    Map(
+      "ALL"          -> ConsistencyLevel.ALL,
+      "ANY"          -> ConsistencyLevel.ANY,
+      "EACH_QUORUM"  -> ConsistencyLevel.EACH_QUORUM,
+      "LOCAL_ONE"    -> ConsistencyLevel.LOCAL_ONE,
+      "LOCAL_QUORUM" -> ConsistencyLevel.LOCAL_QUORUM,
+      "LOCAL_SERIAL" -> ConsistencyLevel.LOCAL_SERIAL,
+      "ONE"          -> ConsistencyLevel.ONE,
+      "QUORUM"       -> ConsistencyLevel.QUORUM,
+      "SERIAL"       -> ConsistencyLevel.SERIAL,
+      "THREE"        -> ConsistencyLevel.THREE,
+      "TWO"          -> ConsistencyLevel.TWO
+    )
 
-  implicit val protocolVersions: List[(String, ProtocolVersion)] =
-    ("V1", ProtocolVersion.V1) ::
-      ("V2", ProtocolVersion.V2) ::
-      ("V3", ProtocolVersion.V3) ::
-      ("V4", ProtocolVersion.V4) ::
-      ("V5", ProtocolVersion.V5) :: Nil
+  implicit val protocolVersions: Map[String, ProtocolVersion] =
+    Map(
+      "V1" -> ProtocolVersion.V1,
+      "V2" -> ProtocolVersion.V2,
+      "V3" -> ProtocolVersion.V3,
+      "V4" -> ProtocolVersion.V4,
+      "V5" -> ProtocolVersion.V5)
 
-  implicit val compressions: List[(String, Compression)] =
-    ("lz4", Compression.LZ4) :: ("snappy", Compression.SNAPPY) :: ("none", Compression.NONE) :: Nil
+  implicit val compressions: Map[String, Compression] =
+    Map("lz4" -> Compression.LZ4, "snappy" -> Compression.SNAPPY, "none" -> Compression.NONE)
 
   implicit val credentialsRead: Read[Config, Credentials] = Read.instance[Config, Credentials] {
     path =>

--- a/core/src/main/scala/config/implicits/package.scala
+++ b/core/src/main/scala/config/implicits/package.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra
+package config
+
+import classy.DecodeError.WrongType
+import classy.{Decoder, Read}
+import classy.config._
+import com.typesafe.config.Config
+
+import scala.util.{Failure, Success, Try}
+
+package object implicits {
+
+  def instanceRead[T](implicit m: reflect.Manifest[T]): Read[Config, T] =
+    read[String, T] { value =>
+      Try(Class.forName(value).newInstance().asInstanceOf[T]) match {
+        case Failure(_) =>
+          Decoder.fail(WrongType(s"subclass of ${m.runtimeClass.getName}", Some(value)))
+        case Success(c) => Decoder.const(c)
+      }
+    }
+
+  implicit def stringListRead[T](implicit list: List[(String, T)]): Read[Config, T] =
+    read[String, T] { value =>
+      list.find(_._1 == value) match {
+        case Some((_, v)) => Decoder.const(v)
+        case None         => Decoder.fail(WrongType(list.map(_._1).mkString(" | "), Some(value)))
+      }
+    }
+
+  def read[A, B](f: A => ConfigDecoder[B])(implicit R: Read[Config, A]): Read[Config, B] =
+    Read.instance[Config, B](path => readConfig[A](path).flatMap(f))
+
+}

--- a/core/src/main/scala/config/implicits/package.scala
+++ b/core/src/main/scala/config/implicits/package.scala
@@ -35,11 +35,11 @@ package object implicits {
       }
     }
 
-  implicit def stringListRead[T](implicit list: List[(String, T)]): Read[Config, T] =
+  implicit def stringListRead[T](implicit map: Map[String, T]): Read[Config, T] =
     read[String, T] { value =>
-      list.find(_._1 == value) match {
-        case Some((_, v)) => Decoder.const(v)
-        case None         => Decoder.fail(WrongType(list.map(_._1).mkString(" | "), Some(value)))
+      map.get(value) match {
+        case Some(v) => Decoder.const(v)
+        case None    => Decoder.fail(WrongType(map.keys.mkString(" | "), Some(value)))
       }
     }
 

--- a/core/src/main/scala/config/model.scala
+++ b/core/src/main/scala/config/model.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra
+package config
+
+import java.net.{InetAddress, InetSocketAddress}
+
+import com.datastax.driver.core.HostDistance
+
+sealed trait ContactPoints                                         extends Product with Serializable
+case class ContactPointList(list: List[InetAddress])               extends ContactPoints
+case class ContactPointWithPortList(list: List[InetSocketAddress]) extends ContactPoints
+
+case class Credentials(username: String, password: String)
+
+case class ConnectionsPerHost(distance: HostDistance, core: Int, max: Int)
+case class CoreConnectionsPerHost(distance: HostDistance, newCoreConnections: Int)
+case class MaxConnectionsPerHost(distance: HostDistance, newMaxConnections: Int)
+case class MaxRequestsPerConnection(distance: HostDistance, newMaxRequests: Int)
+case class NewConnectionThreshold(distance: HostDistance, newValue: Int)


### PR DESCRIPTION
Fixes #11 

This PR adds the cluster configuration for Typesafe config using case classy

It's divided in four parts:
* The [model](https://github.com/frees-io/freestyle-cassandra/compare/ff-cluster-config?expand=1#diff-db300d81fc07d5c6df90f12614000452) that includes some classes for a easier decoding
* An [`implicits` package object](https://github.com/frees-io/freestyle-cassandra/compare/ff-cluster-config?expand=1#diff-ec8e5f6e4732fe7511e0403c527f5077) with some utilities for `Read` and `Decoder`
* The [`datastax` object](https://github.com/frees-io/freestyle-cassandra/compare/ff-cluster-config?expand=1#diff-756106cc7b81021d86054851c78795d9) with some specific `Read` instances for the datastax driver classes
* The [`decoders` object](https://github.com/frees-io/freestyle-cassandra/compare/ff-cluster-config?expand=1#diff-04375065fd38626cbc8253850d3461ca) with the `PoolingOptions`, `QueryOptions`, `SocketOptions` and `Cluster.Builder` decoders. Because these classes follow the builder pattern, the `decoders` object contains an abstract class for ease the construction of builder based decoders 

Please @juanpedromoreno could you review? Thanks

@andyscott please, could you take a look when you have a chance? Thanks