### PR TITLE
Adds statement config model and tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val commonDependencies: Seq[ModuleID] = Seq(
 )
 
 lazy val testDependencies: Seq[ModuleID] =
-  Seq(%%("scalatest"), %%("scalamockScalatest"), %%("scalacheck")) map (_  % "test")
+  Seq(%%("scalatest"), %%("scalamockScalatest"), %%("scalacheck"), %%("scheckShapeless")) map (_  % "test")
 
 lazy val root = project
   .in(file("."))

--- a/core/src/main/scala/config/implicits/package.scala
+++ b/core/src/main/scala/config/implicits/package.scala
@@ -20,6 +20,7 @@ package config
 import classy.DecodeError.WrongType
 import classy.{Decoder, Read}
 import classy.config._
+import com.datastax.driver.core.Statement
 import com.typesafe.config.Config
 
 import scala.util.{Failure, Success, Try}
@@ -45,5 +46,36 @@ package object implicits {
 
   def read[A, B](f: A => ConfigDecoder[B])(implicit R: Read[Config, A]): Read[Config, B] =
     Read.instance[Config, B](path => readConfig[A](path).flatMap(f))
+
+  final class ConfigStatementOps(cs: ConfigStatement) {
+
+    def applyConf(st: Statement): Statement = {
+
+      import scala.collection.JavaConverters._
+
+      cs.tracingEnabled foreach {
+        case true  => st.enableTracing()
+        case false => st.disableTracing()
+      }
+      cs.consistencyLevel foreach st.setConsistencyLevel
+      cs.serialConsistencyLevel foreach st.setSerialConsistencyLevel
+      cs.defaultTimestamp foreach st.setDefaultTimestamp
+      cs.fetchSize foreach st.setFetchSize
+      cs.idempotent foreach st.setIdempotent
+      cs.outgoingPayload foreach (m => st.setOutgoingPayload(m.asJava))
+      cs.pagingState foreach {
+        case CodecPagingState(ps, Some(cr)) => st.setPagingState(ps, cr)
+        case CodecPagingState(ps, None)     => st.setPagingState(ps)
+        case RawPagingState(array)          => st.setPagingStateUnsafe(array)
+      }
+      cs.readTimeoutMillis foreach st.setReadTimeoutMillis
+      cs.retryPolicy foreach st.setRetryPolicy
+      st
+    }
+
+  }
+
+  implicit def configStatementOps(cs: ConfigStatement): ConfigStatementOps =
+    new ConfigStatementOps(cs)
 
 }

--- a/core/src/main/scala/config/model.scala
+++ b/core/src/main/scala/config/model.scala
@@ -18,8 +18,10 @@ package freestyle.cassandra
 package config
 
 import java.net.{InetAddress, InetSocketAddress}
+import java.nio.ByteBuffer
 
-import com.datastax.driver.core.HostDistance
+import com.datastax.driver.core.policies.RetryPolicy
+import com.datastax.driver.core.{CodecRegistry, ConsistencyLevel, HostDistance, PagingState}
 
 sealed trait ContactPoints                                         extends Product with Serializable
 case class ContactPointList(list: List[InetAddress])               extends ContactPoints
@@ -32,3 +34,20 @@ case class CoreConnectionsPerHost(distance: HostDistance, newCoreConnections: In
 case class MaxConnectionsPerHost(distance: HostDistance, newMaxConnections: Int)
 case class MaxRequestsPerConnection(distance: HostDistance, newMaxRequests: Int)
 case class NewConnectionThreshold(distance: HostDistance, newValue: Int)
+
+case class ConfigStatement(
+    tracingEnabled: Option[Boolean] = None,
+    consistencyLevel: Option[ConsistencyLevel] = None,
+    serialConsistencyLevel: Option[ConsistencyLevel] = None,
+    defaultTimestamp: Option[Long] = None,
+    fetchSize: Option[Int] = None,
+    idempotent: Option[Boolean] = None,
+    outgoingPayload: Option[Map[String, ByteBuffer]] = None,
+    pagingState: Option[ConfigPagingState] = None,
+    readTimeoutMillis: Option[Int] = None,
+    retryPolicy: Option[RetryPolicy] = None)
+
+sealed trait ConfigPagingState                      extends Product with Serializable
+case class RawPagingState(pagingState: Array[Byte]) extends ConfigPagingState
+case class CodecPagingState(pagingState: PagingState, codecRegistry: Option[CodecRegistry])
+    extends ConfigPagingState

--- a/core/src/test/scala/com/datastax/driver/core/CoreClasses.scala
+++ b/core/src/test/scala/com/datastax/driver/core/CoreClasses.scala
@@ -15,6 +15,7 @@
  */
 
 package com.datastax.driver.core
+import java.nio.ByteBuffer
 import java.util.concurrent.{Executor, TimeUnit}
 
 object CloseFutureTest extends CloseFuture {
@@ -37,4 +38,12 @@ object ResultSetFutureTest extends ResultSetFuture {
   override def get(): ResultSet = null
 
   override def get(timeout: Long, unit: TimeUnit): ResultSet = null
+}
+
+class StatementTest extends Statement {
+  override def getRoutingKey(
+      protocolVersion: ProtocolVersion,
+      codecRegistry: CodecRegistry): ByteBuffer = null
+
+  override def getKeyspace: String = null
 }

--- a/core/src/test/scala/config/ConfigArbitraries.scala
+++ b/core/src/test/scala/config/ConfigArbitraries.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra
+package config
+
+import java.nio.ByteBuffer
+
+import com.datastax.driver.core.{CodecRegistry, ConsistencyLevel, PagingState}
+import org.scalacheck.{Arbitrary, Gen}
+import com.datastax.driver.core.policies.{
+  DefaultRetryPolicy,
+  DowngradingConsistencyRetryPolicy,
+  FallthroughRetryPolicy,
+  RetryPolicy
+}
+
+trait ConfigArbitraries {
+
+  implicit val consistencyLevelArbitrary: Arbitrary[ConsistencyLevel] = Arbitrary {
+    Gen.oneOf(
+      ConsistencyLevel.ALL,
+      ConsistencyLevel.ANY,
+      ConsistencyLevel.EACH_QUORUM,
+      ConsistencyLevel.LOCAL_ONE,
+      ConsistencyLevel.LOCAL_QUORUM,
+      ConsistencyLevel.LOCAL_SERIAL,
+      ConsistencyLevel.ONE,
+      ConsistencyLevel.QUORUM,
+      ConsistencyLevel.SERIAL,
+      ConsistencyLevel.THREE,
+      ConsistencyLevel.TWO
+    )
+  }
+
+  implicit val byteBufferArbitrary: Arbitrary[ByteBuffer] = Arbitrary {
+    Gen.identifier map (s => ByteBuffer.wrap(s.getBytes))
+  }
+
+  implicit val rawPagingStateArbitrary: Arbitrary[RawPagingState] = Arbitrary {
+    Gen.identifier map (s => RawPagingState(s.getBytes))
+  }
+
+  implicit val codecPagingStateArbitrary: Arbitrary[CodecPagingState] = Arbitrary {
+
+    // Valid PagingState String just to skip the validations
+    val validPagingState: String =
+      "0018001010ed3c639da1694885beaa7812eb9202db00f07ffffffd0090a0593939dbd419cd9f9aa16271a49e0004"
+
+    Gen.option(CodecRegistry.DEFAULT_INSTANCE) map { codecRegistry =>
+      CodecPagingState(PagingState.fromString(validPagingState), codecRegistry)
+    }
+  }
+
+  implicit val retryPolicyArbitrary: Arbitrary[RetryPolicy] = Arbitrary {
+    Gen.oneOf(
+      DefaultRetryPolicy.INSTANCE,
+      DowngradingConsistencyRetryPolicy.INSTANCE,
+      FallthroughRetryPolicy.INSTANCE
+    )
+  }
+
+}
+
+object ConfigArbitraries extends ConfigArbitraries

--- a/core/src/test/scala/config/ConfigStatementOpsSpec.scala
+++ b/core/src/test/scala/config/ConfigStatementOpsSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra
+package config
+
+import com.datastax.driver.core.{CodecRegistry, PagingState, Statement, StatementTest}
+import org.scalacheck.Prop._
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.prop.Checkers
+import org.scalatest.{Matchers, WordSpec}
+
+class ConfigStatementOpsSpec extends WordSpec with Matchers with Checkers with MockFactory {
+
+  import ConfigArbitraries._
+  import org.scalacheck.Shapeless._
+  import config.implicits._
+  import scala.collection.JavaConverters._
+
+  "ConfigStatementOps" should {
+
+    "apply all specified values to the statement" in {
+      check {
+        forAll { cs: ConfigStatement =>
+          val st: Statement = mock[StatementTest]
+          cs.tracingEnabled foreach {
+            case true  => (st.enableTracing _).expects().returns(st)
+            case false => (st.disableTracing _).expects().returns(st)
+          }
+          cs.consistencyLevel foreach (v => (st.setConsistencyLevel _).expects(v).returns(st))
+          cs.serialConsistencyLevel foreach (v =>
+            (st.setSerialConsistencyLevel _).expects(v).returns(st))
+          cs.defaultTimestamp foreach (v => (st.setDefaultTimestamp _).expects(v).returns(st))
+          cs.fetchSize foreach (v => (st.setFetchSize _).expects(v).returns(st))
+          cs.idempotent foreach (v => (st.setIdempotent _).expects(v).returns(st))
+          cs.outgoingPayload foreach (v => (st.setOutgoingPayload _).expects(v.asJava).returns(st))
+          cs.pagingState foreach {
+            case CodecPagingState(ps, Some(cr)) =>
+              (st.setPagingState(_: PagingState, _: CodecRegistry)).expects(ps, cr).returns(st)
+            case CodecPagingState(ps, None) =>
+              (st.setPagingState(_: PagingState)).expects(ps).returns(st)
+            case RawPagingState(array) =>
+              (st.setPagingStateUnsafe _).expects(array).returns(st)
+          }
+          cs.readTimeoutMillis foreach (v => (st.setReadTimeoutMillis _).expects(v).returns(st))
+          cs.retryPolicy foreach (v => (st.setRetryPolicy _).expects(v).returns(st))
+          cs.applyConf(st) == st
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #28 

It adds a [`case class`](https://github.com/frees-io/freestyle-cassandra/compare/ff-28-statement-config?expand=1#diff-db300d81fc07d5c6df90f12614000452R38) with all configuration params available for statements. Also, includes an [implicit method](https://github.com/frees-io/freestyle-cassandra/compare/ff-28-statement-config?expand=1#diff-ec8e5f6e4732fe7511e0403c527f5077R52) for applying these values to a statement

Please @juanpedromoreno could you review? Thanks