### PR TITLE
CQL Interpolator: Proof of concept

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,8 @@ lazy val commonDependencies: Seq[ModuleID] = Seq(
   %("cassandra-driver-core"),
   %("cassandra-driver-mapping"),
   %("cassandra-driver-extras"),
-  "io.github.cassandra-scala" %% "troy-schema" % "0.4.0"
+  "io.github.cassandra-scala" %% "troy-schema" % "0.4.0",
+  "com.propensive" %% "contextual" % "1.0.1"
 )
 
 lazy val testDependencies: Seq[ModuleID] =
@@ -38,3 +39,15 @@ lazy val core = project
   .settings(resolvers += Resolver.bintrayRepo("tabdulradi", "maven"))
   .settings(libraryDependencies ++= commonDependencies)
   .settings(libraryDependencies ++= testDependencies)
+
+lazy val testMacro = project
+  .in(file("testMacro"))
+  .settings(moduleName := "freestyle-cassandra-test-macro")
+  .settings(scalaMetaSettings)
+  .dependsOn(core)
+
+lazy val test = project
+  .in(file("test"))
+  .settings(moduleName := "freestyle-cassandra-test")
+  .settings(scalaMetaSettings)
+  .dependsOn(core, testMacro)

--- a/core/src/main/scala/query/CQLInterpolator.scala
+++ b/core/src/main/scala/query/CQLInterpolator.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra
+package query
+
+import cats.MonadError
+import cats.data.Validated.{Invalid, Valid}
+import cats.data.ValidatedNel
+import contextual.{Case, Context, Interpolator, Prefix}
+import freestyle.cassandra.schema.{SchemaError, Statement}
+import freestyle.cassandra.schema.provider.{SchemaDefinitionProvider, TroySchemaProvider}
+import freestyle.cassandra.schema.validator.SchemaValidator
+import troy.cql.ast.CqlParser
+
+import scala.util.{Failure, Success, Try}
+
+sealed trait CQLContext extends Context
+case object CQLLiteral  extends CQLContext
+
+class CQLInterpolator(V: SchemaValidator[Try]) extends Interpolator {
+
+  import cats.instances.try_._
+
+  override type ContextType = CQLContext
+  override type Input       = String
+  type Out                  = Statement
+
+  override def contextualize(interpolation: StaticInterpolation): Seq[ContextType] = {
+
+    val cql = interpolation.parts.foldLeft("") {
+      case (prev, _ @Literal(_, string)) => prev + string
+      case (prev, _ @Hole(_, _))         => prev + "?"
+      case (prev, _)                     => prev
+    }
+
+    parseStatement[Try](cql).flatMap(V.validateStatement) match {
+      case Success(Valid(_)) =>
+        Seq.fill(interpolation.parts.size)(CQLLiteral)
+      case Success(Invalid(list)) =>
+        interpolation.abort(Literal(0, cql), 0, list.map(_.getMessage).toList.mkString(","))
+      case Failure(e) => interpolation.abort(Literal(0, cql), 0, e.getMessage)
+    }
+  }
+
+  def evaluate[M[_]](interpolation: RuntimeInterpolation)(
+      implicit M: MonadError[M, Throwable]): M[Statement] = {
+    val cql = interpolation.parts.map(_.toString).mkString("")
+    parseStatement[M](cql)
+  }
+
+  private[this] def parseStatement[M[_]](cql: String)(
+      implicit M: MonadError[M, Throwable]): M[Statement] =
+    CqlParser.parseDML(cql) match {
+      case CqlParser.Success(dataManipulation, _) => M.pure(dataManipulation)
+      case CqlParser.Failure(msg, _)              => M.raiseError(new IllegalArgumentException(msg))
+      case CqlParser.Error(msg, _)                => M.raiseError(new IllegalArgumentException(msg))
+    }
+}
+
+object RuntimeCQLInterpolator {
+
+  val schemaValidator: SchemaValidator[Try] = new SchemaValidator[Try] {
+    override def validateStatement(st: Statement)(
+        implicit M: MonadError[Try, Throwable]): Try[ValidatedNel[SchemaError, Unit]] =
+      Success(Valid((): Unit))
+  }
+
+  object cqlInterpolator extends CQLInterpolator(schemaValidator)
+
+  implicit def embedArgsNamesInCql[T] = cqlInterpolator.embed[T](
+    Case(CQLLiteral, CQLLiteral)(_ => "?")
+  )
+
+  final class CQLStringContext(sc: StringContext) {
+    val cql = Prefix(cqlInterpolator, sc)
+  }
+
+  implicit def cqlStringContext(sc: StringContext): CQLStringContext =
+    new CQLStringContext(sc)
+
+}
+
+object TroySchemaCQLInterpolator {
+
+  val M: MonadError[Try, Throwable] = cats.instances.try_.catsStdInstancesForTry
+  val trySchemaProvider: SchemaDefinitionProvider[Try] =
+    TroySchemaProvider[Try](TroySchemaCQLInterpolator.getClass.getResourceAsStream("/schema.sql"))(
+      M)
+  import freestyle.cassandra.schema.validator.TroySchemaValidator
+
+  val troySchemaValidator: SchemaValidator[Try] = TroySchemaValidator.instance(M, trySchemaProvider)
+
+}

--- a/core/src/main/scala/schema/provider/metadata/SchemaConversions.scala
+++ b/core/src/main/scala/schema/provider/metadata/SchemaConversions.scala
@@ -69,8 +69,7 @@ trait SchemaConversions {
         M.map2(columnsM, pKeyM) { (columns, pKey) =>
           CreateTable(
             ifNotExists = false,
-            tableName =
-              TableName(Some(KeyspaceName(metadata.getKeyspace.getName)), metadata.getName),
+            tableName = TableName(Some(KeyspaceName(metadata.getKeyspace.getName)), metadata.getName),
             columns = columns,
             primaryKey = Some(pKey),
             options = Seq.empty

--- a/core/src/main/scala/schema/provider/metadata/SchemaConversions.scala
+++ b/core/src/main/scala/schema/provider/metadata/SchemaConversions.scala
@@ -69,7 +69,8 @@ trait SchemaConversions {
         M.map2(columnsM, pKeyM) { (columns, pKey) =>
           CreateTable(
             ifNotExists = false,
-            tableName = TableName(Some(KeyspaceName(metadata.getKeyspace.getName)), metadata.getName),
+            tableName =
+              TableName(Some(KeyspaceName(metadata.getKeyspace.getName)), metadata.getName),
             columns = columns,
             primaryKey = Some(pKey),
             options = Seq.empty

--- a/test/src/main/scala/TestCompileInterpolator.scala
+++ b/test/src/main/scala/TestCompileInterpolator.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import freestyle.cassandra.schema.Statement
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+object TestCompileInterpolator extends App {
+
+  import freestyle.cassandra.query.interpolator.MyInterpolator._
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  import cats.instances.future._
+
+  val id = 1
+
+  val r: Future[Statement] = cql"SELECT id, name FROM test.users WHERE id = $id;"
+  val st: Statement        = Await.result(r, Duration.Inf)
+  println(st)
+
+}

--- a/test/src/main/scala/TestRuntimeInterpolator.scala
+++ b/test/src/main/scala/TestRuntimeInterpolator.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import freestyle.cassandra.schema.Statement
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+object TestRuntimeInterpolator extends App {
+
+  import freestyle.cassandra.query.RuntimeCQLInterpolator._
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  import cats.instances.future._
+
+  val id = 1
+
+  val r: Future[Statement] = cql"SELECT id, name FROM test.users WHERE id = $id;"
+  val st: Statement        = Await.result(r, Duration.Inf)
+  println(st)
+
+}

--- a/testMacro/src/main/resources/schema.sql
+++ b/testMacro/src/main/resources/schema.sql
@@ -1,0 +1,8 @@
+
+CREATE KEYSPACE test WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : '3'};
+
+CREATE TABLE test.users (
+  id uuid,
+  name text,
+ PRIMARY KEY (id)
+);

--- a/testMacro/src/main/scala/query/interpolator/MyInterpolator.scala
+++ b/testMacro/src/main/scala/query/interpolator/MyInterpolator.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra
+package query.interpolator
+
+import contextual.{Case, Prefix}
+import freestyle.cassandra.query.{CQLInterpolator, CQLLiteral}
+
+object MyInterpolator {
+
+  import freestyle.cassandra.query.TroySchemaCQLInterpolator._
+
+  object cqlInterpolator extends CQLInterpolator(troySchemaValidator)
+
+  implicit def embedArgsNamesInCql[T] = cqlInterpolator.embed[T](
+    Case(CQLLiteral, CQLLiteral)(_ => "?")
+  )
+
+  final class CQLStringContext(sc: StringContext) {
+    val cql = Prefix(cqlInterpolator, sc)
+  }
+
+  implicit def cqlStringContext(sc: StringContext): CQLStringContext =
+    new CQLStringContext(sc)
+
+}


### PR DESCRIPTION
### Proof of Concept - DO NOT MERGE

Fixes #45 

This PR shows a proof of concept about how the interpolator could be implemented using [propensive/contextual](https://github.com/propensive/contextual).

It provides a "runtime interpolator" that doesn't make validations at compile time and some utility methods for creating a "compile time interpolator" in the client.

Because we're validating at compile time we need to provide the schema validator at interpolator definition level.