### PR TITLE
Metadata schema provider from cluster configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val commonDependencies: Seq[ModuleID] = Seq(
   %%("circe-parser"),
   %%("circe-generic"),
   %%("classy-core"),
+  %%("classy-config-typesafe"),
   %("cassandra-driver-core"),
   %("cassandra-driver-mapping"),
   %("cassandra-driver-extras"),
@@ -22,8 +23,7 @@ lazy val testDependencies: Seq[ModuleID] =
     %%("scalatest"),
     %%("scalamockScalatest"),
     %%("scalacheck"),
-    %%("scheckShapeless"),
-    %%("classy-config-typesafe")) map (_  % "test")
+    %%("scheckShapeless")) map (_  % "test")
 
 lazy val root = project
   .in(file("."))

--- a/core/src/main/scala/mapper/package.scala
+++ b/core/src/main/scala/mapper/package.scala
@@ -26,7 +26,7 @@ import shapeless.labelled.FieldType
 package object mapper {
 
   abstract class FieldMapper(val name: String) {
-    def serialize[M[_]](implicit M: MonadError[M, Throwable]): M[ByteBuffer]
+    def serialize[M[_]](implicit E: MonadError[M, Throwable]): M[ByteBuffer]
   }
 
   trait FieldListMapper[A] {
@@ -47,7 +47,7 @@ package object mapper {
       val fieldName = witness.value.name
       createFieldMapper { hlist =>
         val fieldMapper = new FieldMapper(fieldName) {
-          override def serialize[M[_]](implicit M: MonadError[M, Throwable]): M[ByteBuffer] =
+          override def serialize[M[_]](implicit E: MonadError[M, Throwable]): M[ByteBuffer] =
             codec.value.serialize(hlist.head)
         }
         fieldMapper :: tMapper.map(hlist.tail)

--- a/core/src/main/scala/query/interpolator/CQLInterpolator.scala
+++ b/core/src/main/scala/query/interpolator/CQLInterpolator.scala
@@ -41,11 +41,11 @@ class CQLInterpolator(V: SchemaValidator[Try]) extends Interpolator {
       case (prev, _)                     => prev
     }
 
-    def parseStatement[M[_]](cql: String)(implicit M: MonadError[M, Throwable]): M[Statement] =
+    def parseStatement[M[_]](cql: String)(implicit E: MonadError[M, Throwable]): M[Statement] =
       CqlParser.parseDML(cql) match {
-        case CqlParser.Success(dataManipulation, _) => M.pure(dataManipulation)
-        case CqlParser.Failure(msg, _)              => M.raiseError(new IllegalArgumentException(msg))
-        case CqlParser.Error(msg, _)                => M.raiseError(new IllegalArgumentException(msg))
+        case CqlParser.Success(dataManipulation, _) => E.pure(dataManipulation)
+        case CqlParser.Failure(msg, _)              => E.raiseError(new IllegalArgumentException(msg))
+        case CqlParser.Error(msg, _)                => E.raiseError(new IllegalArgumentException(msg))
       }
 
     parseStatement[Try](cql).flatMap(V.validateStatement) match {
@@ -58,8 +58,8 @@ class CQLInterpolator(V: SchemaValidator[Try]) extends Interpolator {
   }
 
   def evaluate[M[_]](interpolation: RuntimeInterpolation)(
-      implicit M: MonadError[M, Throwable]): M[(String, List[OutputValue])] =
-    M.pure {
+      implicit E: MonadError[M, Throwable]): M[(String, List[OutputValue])] =
+    E.pure {
       interpolation.parts.foldLeft(("", List.empty[OutputValue])) {
         case ((cql, values), Literal(_, string)) =>
           (cql + string, values)

--- a/core/src/main/scala/query/interpolator/RuntimeCQLInterpolator.scala
+++ b/core/src/main/scala/query/interpolator/RuntimeCQLInterpolator.scala
@@ -33,7 +33,7 @@ object RuntimeCQLInterpolator {
 
   private[this] val schemaValidator: SchemaValidator[Try] = new SchemaValidator[Try] {
     override def validateStatement(st: Statement)(
-        implicit M: MonadError[Try, Throwable]): Try[ValidatedNel[SchemaError, Unit]] =
+        implicit E: MonadError[Try, Throwable]): Try[ValidatedNel[SchemaError, Unit]] =
       Success(Valid((): Unit))
   }
 
@@ -42,7 +42,7 @@ object RuntimeCQLInterpolator {
   implicit def embedArgsNamesInCql[T](implicit C: ByteBufferCodec[T]) = cqlInterpolator.embed[T](
     Case(CQLLiteral, CQLLiteral) { v =>
       new ValueSerializer {
-        override def serialize[M[_]](implicit M: MonadError[M, Throwable]): M[ByteBuffer] =
+        override def serialize[M[_]](implicit E: MonadError[M, Throwable]): M[ByteBuffer] =
           C.serialize(v)
       }
     }

--- a/core/src/main/scala/query/interpolator/package.scala
+++ b/core/src/main/scala/query/interpolator/package.scala
@@ -28,7 +28,7 @@ package object interpolator {
   case object CQLLiteral  extends CQLContext
 
   trait ValueSerializer {
-    def serialize[M[_]](implicit M: MonadError[M, Throwable]): M[ByteBuffer]
+    def serialize[M[_]](implicit E: MonadError[M, Throwable]): M[ByteBuffer]
   }
 
   case class OutputValue(index: Int, serializer: ValueSerializer)

--- a/core/src/main/scala/schema/package.scala
+++ b/core/src/main/scala/schema/package.scala
@@ -41,9 +41,9 @@ package object schema {
   type Statement        = DataManipulation
 
   def catchNonFatalAsSchemaError[M[_], A](value: => A)(
-      implicit M: MonadError[M, Throwable]): M[A] =
-    M.handleErrorWith(M.catchNonFatal(value)) { e =>
-      M.raiseError(SchemaDefinitionProviderError(e))
+      implicit E: MonadError[M, Throwable]): M[A] =
+    E.handleErrorWith(E.catchNonFatal(value)) { e =>
+      E.raiseError(SchemaDefinitionProviderError(e))
     }
 
 }

--- a/core/src/main/scala/schema/provider/MetadataSchemaProvider.scala
+++ b/core/src/main/scala/schema/provider/MetadataSchemaProvider.scala
@@ -34,7 +34,7 @@ import scala.collection.JavaConverters._
 import scala.language.postfixOps
 
 class MetadataSchemaProvider[M[_]](
-    val clusterProvider: M[Cluster])(implicit AC: AsyncContext[M], API: ClusterAPI[ClusterAPI.Op])
+    clusterProvider: M[Cluster])(implicit AC: AsyncContext[M], API: ClusterAPI[ClusterAPI.Op])
     extends SchemaDefinitionProvider[M]
     with SchemaConversions {
 

--- a/core/src/main/scala/schema/provider/TroySchemaProvider.scala
+++ b/core/src/main/scala/schema/provider/TroySchemaProvider.scala
@@ -25,25 +25,25 @@ import troy.cql.ast.CqlParser
 
 class TroySchemaProvider[M[_]](cqlF: => M[String]) extends SchemaDefinitionProvider[M] {
 
-  override def schemaDefinition(implicit M: MonadError[M, Throwable]): M[SchemaDefinition] =
-    M.flatMap(cqlF) { cql =>
+  override def schemaDefinition(implicit E: MonadError[M, Throwable]): M[SchemaDefinition] =
+    E.flatMap(cqlF) { cql =>
       CqlParser.parseSchema(cql) match {
-        case CqlParser.Success(res, _) => M.pure(res)
+        case CqlParser.Success(res, _) => E.pure(res)
         case CqlParser.Failure(msg, next) =>
-          M.raiseError(
+          E.raiseError(
             SchemaDefinitionProviderError(
               s"Parse Failure: $msg, line = ${next.pos.line}, column = ${next.pos.column}"))
-        case CqlParser.Error(msg, _) => M.raiseError(SchemaDefinitionProviderError(msg))
+        case CqlParser.Error(msg, _) => E.raiseError(SchemaDefinitionProviderError(msg))
       }
     }
 }
 
 object TroySchemaProvider {
 
-  def apply[M[_]](cql: String)(implicit M: MonadError[M, Throwable]): TroySchemaProvider[M] =
-    new TroySchemaProvider(M.pure(cql))
+  def apply[M[_]](cql: String)(implicit E: MonadError[M, Throwable]): TroySchemaProvider[M] =
+    new TroySchemaProvider(E.pure(cql))
 
-  def apply[M[_]](is: InputStream)(implicit M: MonadError[M, Throwable]): TroySchemaProvider[M] =
+  def apply[M[_]](is: InputStream)(implicit E: MonadError[M, Throwable]): TroySchemaProvider[M] =
     new TroySchemaProvider[M](
       catchNonFatalAsSchemaError(scala.io.Source.fromInputStream(is).mkString))
 

--- a/core/src/main/scala/schema/provider/package.scala
+++ b/core/src/main/scala/schema/provider/package.scala
@@ -22,7 +22,7 @@ import cats.MonadError
 package object provider {
 
   trait SchemaDefinitionProvider[M[_]] {
-    def schemaDefinition(implicit M: MonadError[M, Throwable]): M[SchemaDefinition]
+    def schemaDefinition(implicit E: MonadError[M, Throwable]): M[SchemaDefinition]
   }
 
 }

--- a/core/src/main/scala/schema/validator/TroySchemaValidator.scala
+++ b/core/src/main/scala/schema/validator/TroySchemaValidator.scala
@@ -24,12 +24,12 @@ import freestyle.cassandra.schema.provider.SchemaDefinitionProvider
 import troy.schema.{Message, Result, SchemaEngine, V}
 
 class TroySchemaValidator[M[_]](
-    implicit M: MonadError[M, Throwable],
+    implicit E: MonadError[M, Throwable],
     SDP: SchemaDefinitionProvider[M])
     extends SchemaValidator[M] {
 
   override def validateStatement(st: Statement)(
-      implicit M: MonadError[M, Throwable]): M[ValidatedNel[SchemaError, Unit]] = {
+      implicit E: MonadError[M, Throwable]): M[ValidatedNel[SchemaError, Unit]] = {
 
     def toSchemaValidatorError(message: Message): SchemaValidatorError =
       SchemaValidatorError(message.message)
@@ -57,7 +57,7 @@ class TroySchemaValidator[M[_]](
       }
     }
 
-    M.flatMap(SDP.schemaDefinition)(validateStatement(_, st))
+    E.flatMap(SDP.schemaDefinition)(validateStatement(_, st))
   }
 
 }
@@ -65,6 +65,6 @@ class TroySchemaValidator[M[_]](
 object TroySchemaValidator {
 
   implicit def instance[M[_]](
-      implicit M: MonadError[M, Throwable],
+      implicit E: MonadError[M, Throwable],
       SDP: SchemaDefinitionProvider[M]): SchemaValidator[M] = new TroySchemaValidator[M]
 }

--- a/core/src/main/scala/schema/validator/package.scala
+++ b/core/src/main/scala/schema/validator/package.scala
@@ -25,7 +25,7 @@ package object validator {
   trait SchemaValidator[M[_]] {
 
     def validateStatement(st: Statement)(
-        implicit M: MonadError[M, Throwable]): M[ValidatedNel[SchemaError, Unit]]
+        implicit E: MonadError[M, Throwable]): M[ValidatedNel[SchemaError, Unit]]
 
   }
 

--- a/core/src/test/scala/config/TestDecoderUtils.scala
+++ b/core/src/test/scala/config/TestDecoderUtils.scala
@@ -21,12 +21,13 @@ import cats.syntax.option._
 import classy.Decoder
 import com.datastax.driver.core.ProtocolOptions.Compression
 import com.datastax.driver.core._
+import freestyle.cassandra.TestUtils.MatchersUtil
 import freestyle.cassandra.config.ClusterConfig._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.prop.Checkers
 import org.scalatest.{Matchers, WordSpec}
 
-class TestDecoderUtils extends WordSpec with Matchers with Checkers with MockFactory {
+class TestDecoderUtils extends WordSpec with MatchersUtil with Checkers with MockFactory {
 
   import classy.config._
   import com.typesafe.config.Config

--- a/core/src/test/scala/mapper/ByteBufferMapperSpec.scala
+++ b/core/src/test/scala/mapper/ByteBufferMapperSpec.scala
@@ -71,14 +71,14 @@ class ByteBufferMapperSpec extends WordSpec with Matchers with Checkers {
         val Regex: Regex = "(\\d+);(.+)".r
 
         override def deserialize[M[_]](bytes: ByteBuffer)(
-            implicit M: MonadError[M, Throwable]): M[B] =
-          M.flatMap(stringCodec.deserialize(bytes)) {
-            case Regex(v1, v2) => M.pure(B(v1.toLong, v2))
-            case _             => M.raiseError[B](new RuntimeException("Bad serialized value"))
+            implicit E: MonadError[M, Throwable]): M[B] =
+          E.flatMap(stringCodec.deserialize(bytes)) {
+            case Regex(v1, v2) => E.pure(B(v1.toLong, v2))
+            case _             => E.raiseError[B](new RuntimeException("Bad serialized value"))
           }
 
         override def serialize[M[_]](value: B)(
-            implicit M: MonadError[M, Throwable]): M[ByteBuffer] =
+            implicit E: MonadError[M, Throwable]): M[ByteBuffer] =
           stringCodec.serialize(value.b1 + ";" + value.b2)
       }
 

--- a/core/src/test/scala/query/interpolator/CQLInterpolatorSpec.scala
+++ b/core/src/test/scala/query/interpolator/CQLInterpolatorSpec.scala
@@ -33,11 +33,11 @@ class CQLInterpolatorSpec extends WordSpec with Matchers {
 
     "provide a cql interpolator" in {
 
-      implicit val M: MonadError[Try, Throwable] = cats.instances.try_.catsStdInstancesForTry
+      implicit val E: MonadError[Try, Throwable] = cats.instances.try_.catsStdInstancesForTry
 
       val schemaValidator: SchemaValidator[Try] = new SchemaValidator[Try] {
         override def validateStatement(st: Statement)(
-            implicit M: MonadError[Try, Throwable]): Try[ValidatedNel[SchemaError, Unit]] =
+            implicit E: MonadError[Try, Throwable]): Try[ValidatedNel[SchemaError, Unit]] =
           Success(Valid((): Unit))
       }
 

--- a/core/src/test/scala/query/interpolator/RuntimeCQLInterpolatorSpec.scala
+++ b/core/src/test/scala/query/interpolator/RuntimeCQLInterpolatorSpec.scala
@@ -30,7 +30,7 @@ class RuntimeCQLInterpolatorSpec extends WordSpec with Matchers {
     "return a success for a simple query" in {
 
       import RuntimeCQLInterpolator._
-      implicit val M: MonadError[Try, Throwable] = cats.instances.try_.catsStdInstancesForTry
+      implicit val E: MonadError[Try, Throwable] = cats.instances.try_.catsStdInstancesForTry
 
       cql"SELECT * FROM users" shouldBe Success(("SELECT * FROM users", Nil))
     }
@@ -38,7 +38,7 @@ class RuntimeCQLInterpolatorSpec extends WordSpec with Matchers {
     "return a success for a query with params" in {
 
       import RuntimeCQLInterpolator._
-      implicit val M: MonadError[Try, Throwable] = cats.instances.try_.catsStdInstancesForTry
+      implicit val E: MonadError[Try, Throwable] = cats.instances.try_.catsStdInstancesForTry
 
       implicit val protocolVersion: ProtocolVersion   = ProtocolVersion.V4
       implicit val stringTypeCodec: TypeCodec[String] = TypeCodec.ascii()
@@ -62,7 +62,7 @@ class RuntimeCQLInterpolatorSpec extends WordSpec with Matchers {
     "not compile for a wrong statement" in {
 
       import RuntimeCQLInterpolator._
-      implicit val M: MonadError[Try, Throwable] = cats.instances.try_.catsStdInstancesForTry
+      implicit val E: MonadError[Try, Throwable] = cats.instances.try_.catsStdInstancesForTry
 
       """cql"Wrong statement"""" shouldNot compile
     }

--- a/core/src/test/scala/schema/validator/SchemaValidatorSpec.scala
+++ b/core/src/test/scala/schema/validator/SchemaValidatorSpec.scala
@@ -46,7 +46,7 @@ class SchemaValidatorSpec extends WordSpec with Matchers with MockFactory {
     "return Unit if the schema provider and the provided function works as expected" in {
       val sv: SchemaValidator[EitherM] = new SchemaValidator[EitherM] {
         override def validateStatement(st: Statement)(
-            implicit M: MonadError[EitherM, Throwable]): Either[
+            implicit E: MonadError[EitherM, Throwable]): Either[
           Throwable,
           ValidatedNel[SchemaError, Unit]] = Right(Validated.valid((): Unit))
       }
@@ -59,7 +59,7 @@ class SchemaValidatorSpec extends WordSpec with Matchers with MockFactory {
       val exc = SchemaDefinitionProviderError("Test error")
       val sv: SchemaValidator[EitherM] = new SchemaValidator[EitherM] {
         override def validateStatement(st: Statement)(
-            implicit M: MonadError[EitherM, Throwable]): Either[
+            implicit E: MonadError[EitherM, Throwable]): Either[
           Throwable,
           ValidatedNel[SchemaError, Unit]] = Left(exc)
       }

--- a/core/src/test/scala/schema/validator/TroySchemaValidatorSpec.scala
+++ b/core/src/test/scala/schema/validator/TroySchemaValidatorSpec.scala
@@ -41,7 +41,7 @@ class TroySchemaValidatorSpec extends WordSpec with MatchersUtil with Checkers {
           implicit val sdp: SchemaDefinitionProvider[EitherM] =
             new SchemaDefinitionProvider[EitherM] {
               override def schemaDefinition(
-                  implicit M: MonadError[EitherM, Throwable]): EitherM[SchemaDefinition] =
+                  implicit E: MonadError[EitherM, Throwable]): EitherM[SchemaDefinition] =
                 Right(Seq(st.keyspace, st.table))
             }
 


### PR DESCRIPTION
Fixes #67 

This PR adds a new builder method for the MetadataSchemaProvider based on a Cluster Configuration.

@raulraja, could you take a look? I'm using some `free` types and not sure if this is the right way to do it.